### PR TITLE
Change initialization order to fix potential segfault in CUDA plugin

### DIFF
--- a/cuda_source/source.cpp
+++ b/cuda_source/source.cpp
@@ -508,14 +508,16 @@ struct DFTTestData {
 
     std::mutex lock;
 
+    // padded shape: (pad_height, pad_width)
+    // NOTE: must be declared before cuFFT handles so it outlives them
+    // (cuFFT handles reference this memory via cufftSetWorkArea)
+    Resource<CUdeviceptr, cuMemFreeCustom, true> d_work_area_or_padded;
+
     // 2-D or 3-D, depends on radius
     Resource<cufftHandle, cufftDestroyCustom, true> rfft_handle;
     Resource<cufftHandle, cufftDestroyCustom, true> irfft_handle;
     Resource<cufftHandle, cufftDestroyCustom, true> subsampled_rfft_handle;
     Resource<cufftHandle, cufftDestroyCustom, true> subsampled_irfft_handle;
-
-    // padded shape: (pad_height, pad_width)
-    Resource<CUdeviceptr, cuMemFreeCustom, true> d_work_area_or_padded;
 
     Resource<CUmodule, cuModuleUnloadCustom> module;
     CUfunction filter_kernel;


### PR DESCRIPTION
When deinitializing and then reinitializing the CUDA plugin, a segmentation fault could occur. This is possible in scenarios involving the usage of VapourSynth's API, such as in av1an. This was tracked down to an order of initialization issue, which is resolved by this change.

Before:

<img width="1894" height="654" alt="dfttest2_broken" src="https://github.com/user-attachments/assets/474d0749-8cd3-4fb1-a05d-0f033ff202ae" />
<img width="1885" height="103" alt="dfttest2_dmesg" src="https://github.com/user-attachments/assets/fcec7b08-0a64-445d-88b2-d4d143846560" />


After:

<img width="1886" height="748" alt="dfttest2_fixed" src="https://github.com/user-attachments/assets/5d08a220-93e3-4b36-990d-7fffb6686f05" />

